### PR TITLE
API Result Pagination

### DIFF
--- a/socialdistribution/api/views.py
+++ b/socialdistribution/api/views.py
@@ -1,5 +1,8 @@
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
+from django.core.paginator import Paginator
+from django.urls import reverse
+
 from .decorators import check_auth
 
 from urllib import parse
@@ -29,17 +32,65 @@ def posts(request):
     # get public posts
     if request.method == "GET":
         # get a list of all "PUBLIC" visibility posts on our node
-        public_posts = Post.objects.filter(visibility="PUBLIC")
+        public_posts = Post.objects.filter(visibility="PUBLIC").order_by('-published')
+
+        # page number query parameter
+        page_number = request.GET.get("page")
+        if page_number is None:
+            page_number = 0
+        else:
+            page_number = int(page_number)
+
+        # page size query parameter
+        page_size = request.GET.get("size")
+        if page_size is None:
+            page_size = 50
+        else:
+            page_size = int(page_size)
+
+        # bad page size
+        if page_size <= 0:
+            response_body = {
+                "query": "posts",
+                "success": False,
+                "message": "Page size must be a positive integer",
+            }
+            return JsonResponse(response_body, status=400)
+
+        # paginates our QuerySet
+        paginator = Paginator(public_posts, page_size)
+
+        # bad page number
+        if page_number < 0 or page_number >= paginator.num_pages:
+            response_body = {
+                "query": "posts",
+                "success": False,
+                "message": "That page does not exist",
+            }
+            return JsonResponse(response_body, status=404)
+
+        # get the page
+        # note: the off-by-ones here are because Paginator is 1-indexed 
+        # and the example article responses are 0-indexed
+        page_obj = paginator.page(str(int(page_number) + 1))
 
         # response body - to be converted into JSON and returned in response
         response_body = {
             "query": "posts",
-            "count": public_posts.count(),
-            "size": "IMPLEMENT PAGINATION",
-            "next": "IMPLEMENT PAGINATION",
-            "previous": "IMPLEMENT PAGINATION",
-            "posts": [post_to_dict(post) for post in public_posts],
+            "count": paginator.count,
+            "size": int(page_size),
+            "posts": [post_to_dict(post, request) for post in page_obj],
         }
+
+        # give a url to the next page if it exists
+        if page_obj.has_next():
+            next_uri = f"/api/posts?page={page_obj.next_page_number() - 1}&size={page_size}"
+            response_body["next"] = request.build_absolute_uri(next_uri)
+
+        # give a url to the previous page if it exists
+        if page_obj.has_previous():
+            previous_uri = f"/api/posts?page={page_obj.previous_page_number() - 1}&size={page_size}"
+            response_body["previous"] = request.build_absolute_uri(previous_uri)
 
         return JsonResponse(response_body)
 
@@ -80,7 +131,7 @@ def posts(request):
         # valid post --> insert to DB
         post = insert_post(request_body)
 
-        return JsonResponse(post_to_dict(post))
+        return JsonResponse(post_to_dict(post, request))
 
     # insert new post
     # note: PUT requires an ID whereas POST does not
@@ -127,7 +178,7 @@ def posts(request):
         # valid post --> insert to DB
         post = insert_post(request_body)
 
-        return JsonResponse(post_to_dict(post))
+        return JsonResponse(post_to_dict(post, request))
 
     # invalid method
     response_body = {
@@ -174,7 +225,7 @@ def single_post(request, post_id):
     if request.method == "GET" and posts.count() > 0:
         response_body = {
             "query": "posts",
-            "post": post_to_dict(posts[0])
+            "post": post_to_dict(posts[0], request)
         }
 
         return JsonResponse(response_body)
@@ -205,7 +256,7 @@ def single_post(request, post_id):
         # valid post --> update existing post
         post = update_post(post_to_update, request_body)
 
-        return JsonResponse(post_to_dict(post))
+        return JsonResponse(post_to_dict(post, request))
 
     # delete a post
     if request.method == "DELETE" and posts.count() > 0:
@@ -261,20 +312,70 @@ def specific_author_posts(request, author_id):
             }
         return JsonResponse(response_body, status=404)
 
-    # TODO: make this faster
-    visible_posts = []
-    for post in Post.objects.filter(author=authors[0]):
-        if author_can_see_post(request.user, post):
-            visible_posts.append(post)
+    author = authors[0]
+    author_posts = Post.objects.filter(author=author)
 
+    # get only visible posts
+    visible_post_ids = [post.id for post in author_posts if author_can_see_post(request.user, post)]
+    visible_author_posts = author_posts.filter(id__in=visible_post_ids).order_by('-published')
+
+    # page number query parameter
+    page_number = request.GET.get("page")
+    if page_number is None:
+        page_number = 0
+    else:
+        page_number = int(page_number)
+
+    # page size query parameter
+    page_size = request.GET.get("size")
+    if page_size is None:
+        page_size = 50
+    else:
+        page_size = int(page_size)
+
+    # bad page size
+    if page_size <= 0:
+        response_body = {
+            "query": "posts",
+            "success": False,
+            "message": "Page size must be a positive integer",
+        }
+        return JsonResponse(response_body, status=400)
+
+    # paginates our QuerySet
+    paginator = Paginator(visible_author_posts, page_size)
+
+    # bad page number
+    if page_number < 0 or page_number >= paginator.num_pages:
+        response_body = {
+            "query": "posts",
+            "success": False,
+            "message": "That page does not exist",
+        }
+        return JsonResponse(response_body, status=404)
+
+    # get the page
+    # note: the off-by-ones here are because Paginator is 1-indexed 
+    # and the example article responses are 0-indexed
+    page_obj = paginator.page(str(int(page_number) + 1))
+
+    # response body - to be converted into JSON and returned in response
     response_body = {
         "query": "posts",
-        "count": len(visible_posts),
-        "size": "IMPLEMENT PAGINATION",
-        "next": "IMPLEMENT PAGINATION",
-        "previous": "IMPLEMENT PAGINATION",
-        "posts": [post_to_dict(post) for post in visible_posts],
+        "count": paginator.count,
+        "size": int(page_size),
+        "posts": [post_to_dict(post, request) for post in page_obj],
     }
+
+    # give a url to the next page if it exists
+    if page_obj.has_next():
+        next_uri = f"/api/author/{author.id}/posts?page={page_obj.next_page_number() - 1}&size={page_size}"
+        response_body["next"] = request.build_absolute_uri(next_uri)
+
+    # give a url to the previous page if it exists
+    if page_obj.has_previous():
+        previous_uri = f"/api/author/{author.id}/posts?page={page_obj.previous_page_number() - 1}&size={page_size}"
+        response_body["previous"] = request.build_absolute_uri(previous_uri)
 
     return JsonResponse(response_body)
 
@@ -291,20 +392,69 @@ def author_posts(request):
         }
         return JsonResponse(response_body, status=405)
 
-    # TODO: make this faster
-    visible_posts = []
-    for post in Post.objects.all():
-        if author_can_see_post(request.user, post):
-            visible_posts.append(post)
+    posts = Post.objects.all()
 
+    # get only visible posts
+    visible_post_ids = [post.id for post in posts if author_can_see_post(request.user, post)]
+    visible_posts = posts.filter(id__in=visible_post_ids).order_by('-published')
+
+    # page number query parameter
+    page_number = request.GET.get("page")
+    if page_number is None:
+        page_number = 0
+    else:
+        page_number = int(page_number)
+
+    # page size query parameter
+    page_size = request.GET.get("size")
+    if page_size is None:
+        page_size = 50
+    else:
+        page_size = int(page_size)
+
+    # bad page size
+    if page_size <= 0:
+        response_body = {
+            "query": "posts",
+            "success": False,
+            "message": "Page size must be a positive integer",
+        }
+        return JsonResponse(response_body, status=400)
+
+    # paginates our QuerySet
+    paginator = Paginator(visible_posts, page_size)
+
+    # bad page number
+    if page_number < 0 or page_number >= paginator.num_pages:
+        response_body = {
+            "query": "posts",
+            "success": False,
+            "message": "That page does not exist",
+        }
+        return JsonResponse(response_body, status=404)
+
+    # get the page
+    # note: the off-by-ones here are because Paginator is 1-indexed 
+    # and the example article responses are 0-indexed
+    page_obj = paginator.page(str(int(page_number) + 1))
+
+    # response body - to be converted into JSON and returned in response
     response_body = {
         "query": "posts",
-        "count": len(visible_posts),
-        "size": "IMPLEMENT PAGINATION",
-        "next": "IMPLEMENT PAGINATION",
-        "previous": "IMPLEMENT PAGINATION",
-        "posts": [post_to_dict(post) for post in visible_posts],
+        "count": paginator.count,
+        "size": int(page_size),
+        "posts": [post_to_dict(post, request) for post in page_obj],
     }
+
+    # give a url to the next page if it exists
+    if page_obj.has_next():
+        next_uri = f"/api/author/posts?page={page_obj.next_page_number() - 1}&size={page_size}"
+        response_body["next"] = request.build_absolute_uri(next_uri)
+
+    # give a url to the previous page if it exists
+    if page_obj.has_previous():
+        previous_uri = f"/api/author/posts?page={page_obj.previous_page_number() - 1}&size={page_size}"
+        response_body["previous"] = request.build_absolute_uri(previous_uri)
 
     return JsonResponse(response_body)
 
@@ -337,18 +487,68 @@ def post_comments(request, post_id):
     # get comments for the post
     if request.method == "GET":
         # get the comments for the post
-        comments = Comment.objects.filter(post=post)
+        comments = Comment.objects.filter(post=post).order_by('-published')
 
+        # page number query parameter
+        page_number = request.GET.get("page")
+        if page_number is None:
+            page_number = 0
+        else:
+            page_number = int(page_number)
+
+        # page size query parameter
+        page_size = request.GET.get("size")
+        if page_size is None:
+            page_size = 50
+        else:
+            page_size = int(page_size)
+
+        # bad page size
+        if page_size <= 0:
+            response_body = {
+                "query": "comments",
+                "success": False,
+                "message": "Page size must be a positive integer",
+            }
+            return JsonResponse(response_body, status=400)
+
+        # paginates our QuerySet
+        paginator = Paginator(comments, page_size)
+
+        # bad page number
+        if page_number < 0 or page_number >= paginator.num_pages:
+            response_body = {
+                "query": "comments",
+                "success": False,
+                "message": "That page does not exist",
+            }
+            return JsonResponse(response_body, status=404)
+
+        # get the page
+        # note: the off-by-ones here are because Paginator is 1-indexed 
+        # and the example article responses are 0-indexed
+        page_obj = paginator.page(str(int(page_number) + 1))
+
+        # response body - to be converted into JSON and returned in response
         response_body = {
             "query": "comments",
-            "count": comments.count(),
-            "size": "IMPLEMENT PAGINATION",
-            "next": "IMPLEMENT PAGINATION",
-            "previous": "IMPLEMENT PAGINATION",
-            "comments": [comment_to_dict(comment) for comment in comments],
+            "count": paginator.count,
+            "size": int(page_size),
+            "posts": [comment_to_dict(comment) for comment in page_obj],
         }
 
+        # give a url to the next page if it exists
+        if page_obj.has_next():
+            next_uri = f"/api/posts/{post.id}/comments?page={page_obj.next_page_number() - 1}&size={page_size}"
+            response_body["next"] = request.build_absolute_uri(next_uri)
+
+        # give a url to the previous page if it exists
+        if page_obj.has_previous():
+            previous_uri = f"/api/posts/{post.id}/comments?page={page_obj.previous_page_number() - 1}&size={page_size}"
+            response_body["previous"] = request.build_absolute_uri(previous_uri)
+
         return JsonResponse(response_body)
+
 
     # post a comment
     elif request.method == "POST":


### PR DESCRIPTION
Pagination is now complete for our API.

You can now get pages of results using query parameters.

e.g `GET /api/posts?page=0&size=10` gets the first 10 posts, ordered by date (newest first). Included in the result body are urls to the previous and next pages.

Closes #48 