### PR TITLE
Save github activity as posts

### DIFF
--- a/socialdistribution/api/urls.py
+++ b/socialdistribution/api/urls.py
@@ -52,7 +52,7 @@ urlpatterns = [
         csrf_exempt(views.can_see),
         name="api_can_see"),
     path(
-        "author/<uuid:author_id>/github",
+        "author/github",
         csrf_exempt(views.github_posts),
         name= "api_get_author_github_posts"
     )

--- a/socialdistribution/api/urls.py
+++ b/socialdistribution/api/urls.py
@@ -51,4 +51,9 @@ urlpatterns = [
         "cansee/<uuid:author_id>/<uuid:post_id>",
         csrf_exempt(views.can_see),
         name="api_can_see"),
+    path(
+        "author/<uuid:author_id>/github",
+        csrf_exempt(views.github_posts),
+        name= "api_get_author_github_posts"
+    )
 ]

--- a/socialdistribution/api/views.py
+++ b/socialdistribution/api/views.py
@@ -832,16 +832,28 @@ def author_profile(request, author_id):
     return JsonResponse(response_body, status=405)
 
 @check_auth
-def github_posts(request, author_id):
+def github_posts(request):
     if request.method == "GET":
-        author = Author.objects.get(id=author_id)
+        author = request.user
 
         # get the github activities of the author
+        github_name = author.github
+        # if user doesn't have a github account, return 404
+        if github_name == '':
+            response_body = {
+                "query": "github_posts",
+                "success": False,
+                "message": "The author isn't linked to a github account",
+            }
+            return JsonResponse(response_body, status=404)
+
         github_name = author.github.split("/")[3]
         github_name = github_name.lower();
         github_url = 'https://api.github.com/users/' + github_name + '/events'
         r = requests.get(url = github_url)
 
+        # if the github api doesn't return 200,
+        # then return whatever the github api endpoint returns
         if r.status_code != 200:
             response_body = {
                 "query": "github_posts",
@@ -855,7 +867,7 @@ def github_posts(request, author_id):
 
             git_id = activity['id']
             existing_post = Post.objects.filter(author=author, description=git_id).exists()
-            print(git_id)
+
             if not existing_post:
                 title = activity['type']
                 published = activity['created_at']
@@ -863,21 +875,20 @@ def github_posts(request, author_id):
                 repo_name = activity['repo']['name']
                 payload = activity['payload']
 
-                content = "<a class=\"post-card-text\" href=\"https://github.com/"+ repo_name + "\">"+ repo_name +"</a>"
+                content = "["+ repo_name +"](https://github.com/"+ repo_name + ") \r\n "
                 if type == 'PullRequestEvent':
-                    content += "<p>"+ payload['pull_request']['body'] +"</p>"
+                    content += payload['pull_request']['body']
                 elif type == 'PushEvent':
                     for i in range(payload['size']):
-                        content += "<p><a href=\""+ payload['commits'][i]['url'] +"\">"+ payload['commits'][i]['message']+ "</a></p>"
+                        content += "["+ payload['commits'][i]['message'].replace('\n\n', ' ') +"]("+ payload['commits'][i]['url'] + ") \r\n "
                 elif type == 'PullRequestReviewCommentEvent':
-                    content += "<p>"+ payload['comment']['body'] +"</p>"
+                    content += payload['comment']['body']
                 elif type == 'IssueCommentEvent':
-                    content += "<p><a href=\""+ payload['comment']['html_url'] +"\">detail</a></p>"
+                    content += "[Detail]("+ payload['comment']['html_url'] + ")"
                 elif type == 'IssuesEvent':
-                    content += "<p><a href=\""+ payload['issue']['html_url'] +"\">"+ payload['issue']['title']+ "</a></p>"
+                    content += "["+ payload['issue']['title'] +"]("+ payload['issue']['html_url'] + ")"
 
                 github_post = Post(author=author, title=title, description=git_id, content=content, published=published, contentType='text/plain')
-
                 github_post.save()
 
         response_body = {

--- a/socialdistribution/posts/views.py
+++ b/socialdistribution/posts/views.py
@@ -85,7 +85,7 @@ def edit_post(request, post_id):
     post = Post.objects.get(id=post_id)
     friendList = getFriendsOfAuthor(author)
 
-    if (author != post.author):
+    if author != post.author or post.description != '':
         return render(request, "403.html")
 
     form = PostForm(request.POST or None, request.FILES or None,

--- a/socialdistribution/static/js/posts_stream.js
+++ b/socialdistribution/static/js/posts_stream.js
@@ -1,86 +1,100 @@
 /**
  * Displays the Github activities of the user
- * 
+ *
  * Append all Githb events at the bottom of all posts in the /stream
- * 
+ *
  */
-var markup = '<div class="post-card" id="github-post">\
-<!--start of the post heading-->\
-<div class="post-heading">\
-    <div class="post-author">\
-        <div class="post-author-img">\
-            <img src="${event.actor.avatar_url}"  alt="">\
-        </div>\
-        <div class="post-author-body">\
-            <p class="post-author-name">${event.type}</p>\
-            <p >${event.actor.display_login}</p>\
-            <p class="post-timestamp" data-date="${event.created_at}">${event.created_at}</p>\
-        </div>\
-    </div>\
-</div>\
-<!--end of the post heading-->\
-<!--start of the post item-->\
-<div class="post-item">\
-    <a class="post-card-text" href="https://github.com/${event.repo.name}">${event.repo.name}</a>\
-    {{if event.type == "PullRequestEvent"}}\
-    <p>${event.payload.pull_request.body}</p>\
-    {{else event.type == "PullRequestReviewCommentEvent" }}\
-    <p>${event.payload.comment.body}</p>\
-    {{else event.type == "IssueCommentEvent" }}\
-    <p><a href="${event.payload.comment.html_url}">detail</a></p>\
-    {{else event.type == "IssuesEvent" }}\
-    <p><a href="${event.payload.issue.html_url}">${event.payload.issue.title}</a></p>\
-    {{/if}}\
-</div>\
-<!--end of the post item-->\
-<!--start of the post base-->\
-        <div class="post-base">\
-            <span class="label label-danger" style="float:left;">GITHUB</span>\
-        </div>\
-<!--end of the post base-->'
+// var markup = '<div class="post-card" id="github-post">\
+// <!--start of the post heading-->\
+// <div class="post-heading">\
+//     <div class="post-author">\
+//         <div class="post-author-img">\
+//             <img src="${event.actor.avatar_url}"  alt="">\
+//         </div>\
+//         <div class="post-author-body">\
+//             <p class="post-author-name">${event.type}</p>\
+//             <p >${event.actor.display_login}</p>\
+//             <p class="post-timestamp" data-date="${event.created_at}">${event.created_at}</p>\
+//         </div>\
+//     </div>\
+// </div>\
+// <!--end of the post heading-->\
+// <!--start of the post item-->\
+// <div class="post-item">\
+//     <a class="post-card-text" href="https://github.com/${event.repo.name}">${event.repo.name}</a>\
+//     {{if event.type == "PullRequestEvent"}}\
+//     <p>${event.payload.pull_request.body}</p>\
+//     {{else event.type == "PullRequestReviewCommentEvent" }}\
+//     <p>${event.payload.comment.body}</p>\
+//     {{else event.type == "IssueCommentEvent" }}\
+//     <p><a href="${event.payload.comment.html_url}">detail</a></p>\
+//     {{else event.type == "IssuesEvent" }}\
+//     <p><a href="${event.payload.issue.html_url}">${event.payload.issue.title}</a></p>\
+//     {{/if}}\
+// </div>\
+// <!--end of the post item-->\
+// <!--start of the post base-->\
+//         <div class="post-base">\
+//             <span class="label label-danger" style="float:left;">GITHUB</span>\
+//         </div>\
+// <!--end of the post base-->'
 
 
 $(document).ready(function() {
-    var authorId = $(".profile-header-info").attr("id");
-    var githubName;
-    $.template( "githubTemplate", markup );
+  var authorId = $(".profile-header-info").attr("id");
 
-    /**
-     * Get the Github Account of the authenticated user,
-     * and then make a Github API event request to get all the events
-     * from the Github.
-     */
+  $("#load_github").click(function(){
     $.ajax({
-        url: '/api/author/' + authorId,
-        method: 'GET',
-        success: function(result) {
-            githubName = result.github.split("/")[3];
-            githubName = githubName.toLowerCase();
-        },
-        error: function(request,msg,error) {
-            console.log('fail to get user github');
-        }
-    }).done(function() {
-        $.ajax({
-            url: 'https://api.github.com/users/' + githubName + '/events',
-            method: 'GET',
-            success: function(events) {
-                for (event of events) {
-                    // console.log(event);
-                    // console.log(event.created_at);
-                    // console.log($(template_author).ready());
-                    $.tmpl( "githubTemplate", event ).appendTo("#my-stream" );
-                };
-            },
-            error: function(request,msg,error) {
-                console.log('fail to get the the github stream');
-            }
-        });  
-    }); 
+      url: '/api/author/' + authorId +'/github',
+      method: 'GET',
+      success: function(result) {
+        location.replace(location.origin + '/stream');
+      },
+      error: function(request,msg,error) {
+          alert("Can't load your github activities");
+      }
+    });
+  });
+
+    // var githubName;
+    // $.template( "githubTemplate", markup );
+    //
+    // /**
+    //  * Get the Github Account of the authenticated user,
+    //  * and then make a Github API event request to get all the events
+    //  * from the Github.
+    //  */
+    // $.ajax({
+    //     url: '/api/author/' + authorId,
+    //     method: 'GET',
+    //     success: function(result) {
+    //         githubName = result.github.split("/")[3];
+    //         githubName = githubName.toLowerCase();
+    //     },
+    //     error: function(request,msg,error) {
+    //         console.log('fail to get user github');
+    //     }
+    // }).done(function() {
+    //     $.ajax({
+    //         url: 'https://api.github.com/users/' + githubName + '/events',
+    //         method: 'GET',
+    //         success: function(events) {
+    //             for (event of events) {
+    //                 // console.log(event);
+    //                 // console.log(event.created_at);
+    //                 // console.log($(template_author).ready());
+    //                 $.tmpl( "githubTemplate", event ).appendTo("#my-stream" );
+    //             };
+    //         },
+    //         error: function(request,msg,error) {
+    //             console.log('fail to get the the github stream');
+    //         }
+    //     });
+    // });
 
     /**
      * Handle the filter for the post
-     * 
+     *
      * Show all: Show all the posts.
      * Local: Show the local posts.
      * Remote: Show the remote posts.
@@ -164,7 +178,7 @@ $(document).ready(function() {
         setTimeout(function() {
             var board = $("#my-stream");
             var boards = board.children('.post-card').detach().get();
-        
+
             boards.sort(function(a, b) {
             console.log($(a).find(".post-timestamp").data("date"));
             return new Date($(a).find(".post-timestamp").data("date")) - new Date($(b).find(".post-timestamp").data("date"));

--- a/socialdistribution/static/js/posts_stream.js
+++ b/socialdistribution/static/js/posts_stream.js
@@ -45,7 +45,7 @@ $(document).ready(function() {
 
   $("#load_github").click(function(){
     $.ajax({
-      url: '/api/author/' + authorId +'/github',
+      url: '/api/author/github',
       method: 'GET',
       success: function(result) {
         location.replace(location.origin + '/stream');

--- a/socialdistribution/templates/posts/posts_base.html
+++ b/socialdistribution/templates/posts/posts_base.html
@@ -7,6 +7,9 @@
 <!-- https://www.w3schools.com/howto/howto_js_filter_elements.asp -->
 <!-- Control buttons -->
 <div class="post-back">
+<div id="load_github">
+  <button class="btn btn-danger" id="load_github"> Load my github activities</button>
+</div>
 <div id="myBtnContainer">
     <button class="btn btn-default" id="all"> Show all</button>
     <button class="btn btn-default" id="local"> Local</button>
@@ -20,7 +23,11 @@
 <ul id="my-stream">
 {% if latest_post_list %}
     {% for post in latest_post_list %}
+    {% if post.description == '' %}
     <div class="post-card" id="non-github-post" name="{{ post.visibility }}">
+    {% else %}
+    <div class="post-card" id="github-post">
+    {% endif %}
         <!--start of the post heading-->
         <div class="post-heading">
             <div class="post-author" id="{{ post.author.id }}">
@@ -47,7 +54,7 @@
             {% elif post.contentType == "text/markdown" %}
             <p class="post-card-text">{{ post.content|markdownify }}</p>
             {% else %}
-            <p class="post-card-text">{{ post.content }}</p>
+            <p class="post-card-text">{{ post.content | safe }}</p>
             {% endif %}
             {% if post.categories %}
             {% for category in post.categories %}
@@ -59,7 +66,9 @@
         <!--end of the post item-->
         <!--start of the post base-->
         <div class="post-base">
-            {% if post.visibility == "PUBLIC" %}
+            {% if post.description != "" %}
+            <span class="label label-danger" style="float:left;">GITHUB</span>
+            {% elif post.visibility == "PUBLIC" %}
             <span class="label label-default" style="float:left;">{{ post.visibility }}</span>
             {% elif post.visibility == "PRIVATE" %}
             <span class="label label-success" style="float:left;">{{ post.visibility }}</span>

--- a/socialdistribution/templates/posts/posts_base.html
+++ b/socialdistribution/templates/posts/posts_base.html
@@ -51,10 +51,10 @@
         <div class="post-item" style="overflow: scroll; max-height: 230px;">
             {% if post.contentType == "image/png;base64" or post.contentType == "image/jpeg;base64" %}
             <img class = "imagePost" src="data:{{ post.contentType }},{{ post.content }}" /> <br>
-            {% elif post.contentType == "text/markdown" %}
-            <p class="post-card-text">{{ post.content|markdownify }}</p>
+            {% elif post.contentType == "text/markdown" or post.description != '' %}
+            <p class="post-card-text">{{ post.content|markdownify|linebreaksbr  }}</p>
             {% else %}
-            <p class="post-card-text">{{ post.content | safe }}</p>
+            <p class="post-card-text">{{ post.content|linebreaksbr  }}</p>
             {% endif %}
             {% if post.categories %}
             {% for category in post.categories %}

--- a/socialdistribution/templates/posts/posts_view.html
+++ b/socialdistribution/templates/posts/posts_view.html
@@ -35,10 +35,10 @@
             <h5 class="post-card-title">{{ post.title }}</h5>
             {% if post.contentType == "image/png;base64" or post.contentType == "image/jpeg;base64" %}
             <img src="data:{{ post.contentType }},{{ post.content }}" /><br>
-            {% elif post.contentType == "text/markdown" %}
-            <p class="post-card-text">{{ post.content|markdownify }}</p>
+            {% elif post.contentType == "text/markdown" or post.description != '' %}
+            <p class="post-card-text">{{ post.content|markdownify|linebreaksbr }}</p>
             {% else %}
-            <p class="post-card-text">{{ post.content | safe }}</p>
+            <p class="post-card-text">{{ post.content|linebreaksbr }}</p>
             {% endif %}
             {% if post.categories %}
             {% for category in post.categories_as_list %}

--- a/socialdistribution/templates/posts/posts_view.html
+++ b/socialdistribution/templates/posts/posts_view.html
@@ -24,7 +24,7 @@
             </div>
             <div class="buttons-wrap">
               <button class="btn btn-danger" id="delete-post" style="margin-bottom: 2pt;"><span class="glyphicon glyphicon-trash"></span> Delete</button>
-              {% if author == post.author %}
+              {% if author == post.author and post.description == '' %}
               <a class="btn btn-primary" href="/stream/{{ post.id }}/edit"><span class="glyphicon glyphicon-pencil"></span> Edit</a>
               {% endif %}
             </div>
@@ -38,7 +38,7 @@
             {% elif post.contentType == "text/markdown" %}
             <p class="post-card-text">{{ post.content|markdownify }}</p>
             {% else %}
-            <p class="post-card-text">{{ post.content }}</p>
+            <p class="post-card-text">{{ post.content | safe }}</p>
             {% endif %}
             {% if post.categories %}
             {% for category in post.categories_as_list %}
@@ -49,7 +49,9 @@
         <!--end of the post item-->
         <!--start of the post base-->
         <div class="post-base">
-            {% if post.visibility == "PUBLIC" %}
+            {% if post.description != "" %}
+            <span class="label label-danger" style="float:left; margin-right: 3pt;">GITHUB</span>
+            {% elif post.visibility == "PUBLIC" %}
             <span class="label label-default" style="float:left; margin-right: 3pt;">{{ post.visibility }}</span>
             {% elif post.visibility == "PRIVATE" %}
             <span class="label label-success" style="float:left; margin-right: 3pt;">{{ post.visibility }}</span>


### PR DESCRIPTION
- Create a api endpoint `author/<uuid:author_id>/github` to add any new github events to the database as posts
- Change the templates to filter out non-github posts and github posts
- Create a button to pull the latest events from github for thr user